### PR TITLE
Import virtualenv so that it uses the same Python version.

### DIFF
--- a/build.py
+++ b/build.py
@@ -3,6 +3,8 @@ import shutil
 import subprocess
 import sys
 
+import virtualenv
+
 import vcs
 
 lockfile = None
@@ -45,7 +47,7 @@ def setup_virtualenv():
     virtualenv_path = os.path.join(here, "_virtualenv")
 
     if not os.path.exists(virtualenv_path):
-        subprocess.check_call(["virtualenv", virtualenv_path])
+        virtualenv.create_environment(virtualenv_path)
 
     activate_path = os.path.join(virtualenv_path, "bin", "activate_this.py")
 


### PR DESCRIPTION
`/usr/bin/virtualenv` defaults to Python 3 on my system, so running `python2 build.py` failed to install Mercurial.

This imports virtualenv so that it runs in and defaults to the same Python version that runs `build.py`.
